### PR TITLE
Add navigation, layout, and data components to streamlit sandbox

### DIFF
--- a/sandbox/streamlit-like-jetty/README.md
+++ b/sandbox/streamlit-like-jetty/README.md
@@ -1,0 +1,15 @@
+# streamlit-like-jetty
+
+Questa sandbox illustra una mini applicazione stile Streamlit basata su Jetty. Le API principali sono esposte tramite la classe `UIContext`, che orchestra la generazione di HTML Tailwind per ogni richiesta.
+
+## Componenti di testo
+`src/main/java/it/jui/framework/apis/TextElements.java` fornisce helper per titoli, paragrafi e campi di input decorati con classi TailwindCSS (es. `text-3xl font-bold`, `bg-indigo-600`, `border-gray-300`). Questi metodi aggiungono HTML al contesto tramite `ctx.addHtml(...)` e mantengono lo stato con `ctx.getValue(...)` usando identificativi univoci generati da `ctx.getNextWidgetId(...)`.
+
+## Componenti di stato
+`src/main/java/it/jui/framework/apis/StatusElements.java` aggiunge messaggi di stato e indicatori di caricamento con stili Tailwind (`bg-green-50`, `bg-yellow-50`, progress bar animate). Anche qui `ctx.addHtml(...)` inserisce il markup nella risposta mentre `ctx.getValue(...)` consente di conservare i valori correnti, ad esempio le percentuali delle progress bar.
+
+## Navigazione e layout
+`src/main/java/it/jui/framework/apis/NavigationElements.java` espone tab con stile Tailwind, aggiornando lo stato attivo tramite `sendUpdate(...)` e `ctx.getValue(...)` per evidenziare il pulsante selezionato. `src/main/java/it/jui/framework/apis/LayoutElements.java` propone card e pannelli di metrica con bordi, ombre e colorazione condizionale per gli andamenti (verde/rosso).
+
+## Dati e badge
+`src/main/java/it/jui/framework/apis/DataElements.java` consente di rendere badge colorati e tabelle responsive: gli header e le righe sono generati da liste Java e stilizzati con classi Tailwind (`divide-y`, `rounded-xl`, `dark:*`). Anche qui il markup viene accumulato con `ctx.addHtml(...)`.

--- a/sandbox/streamlit-like-jetty/TestApp.java
+++ b/sandbox/streamlit-like-jetty/TestApp.java
@@ -32,6 +32,27 @@ public class TestApp implements UIApp {
         ui.spinner("spinner");
         ui.progressBar("progress1", 10);
         ui.progressBarAnimated("progress2", 10);
-        
+
+        ui.subheader("Navigazione");
+        String activeTab = ui.tabs("Sezioni", List.of("Profilo", "Team", "Impostazioni"), "Profilo");
+        ui.info("Tab attiva: " + activeTab);
+
+        ui.subheader("Layout & metriche");
+        ui.card("Benvenuto, " + nome + "!", "Riepilogo rapido dei dati forniti: età " + age + ".");
+        ui.metricCard("Utenti attivi", "1.248", "+12% rispetto a ieri", true);
+        ui.metricCard("Errori giornalieri", "12", "-3% rispetto alla media", false);
+
+        ui.subheader("Dati");
+        ui.table(
+            "Ultime richieste",
+            List.of("ID", "Utente", "Stato"),
+            List.of(
+                List.of("#1024", "Anna", "Completata"),
+                List.of("#1025", "Luca", "In corso"),
+                List.of("#1026", "Sara", "In attesa")
+            )
+        );
+        ui.badge("Nuovo", "info");
+
     }
 }

--- a/sandbox/streamlit-like-jetty/src/main/java/it/jui/framework/apis/DataElements.java
+++ b/sandbox/streamlit-like-jetty/src/main/java/it/jui/framework/apis/DataElements.java
@@ -1,0 +1,61 @@
+package it.jui.framework.apis;
+
+import java.util.List;
+
+import it.jui.framework.core.UIContext;
+
+public class DataElements extends BaseElements {
+
+    public DataElements(UIContext ctx) {
+        super(ctx);
+    }
+
+    public void table(String title, List<String> headers, List<List<String>> rows) {
+        StringBuilder head = new StringBuilder();
+        for (String h : headers) {
+            head.append(String.format(
+                "<th scope='col' class='px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-300'>%s</th>",
+                h));
+        }
+
+        StringBuilder body = new StringBuilder();
+        for (List<String> row : rows) {
+            body.append("<tr class='border-b border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800/60'>");
+            for (String cell : row) {
+                body.append(String.format(
+                    "<td class='px-6 py-4 text-sm text-gray-700 dark:text-gray-200'>%s</td>",
+                    cell));
+            }
+            body.append("</tr>");
+        }
+
+        ctx.addHtml(String.format(
+            "<div class='mb-6 overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm'>" +
+            "<div class='px-4 py-3 bg-gray-50 dark:bg-gray-900/40 border-b border-gray-200 dark:border-gray-700'>" +
+            "<h3 class='text-sm font-semibold text-gray-800 dark:text-gray-100'>%s</h3>" +
+            "</div>" +
+            "<div class='overflow-x-auto'>" +
+            "<table class='min-w-full divide-y divide-gray-200 dark:divide-gray-700'>" +
+            "<thead class='bg-gray-50 dark:bg-gray-900/60'><tr>%s</tr></thead>" +
+            "<tbody class='bg-white dark:bg-gray-800'>%s</tbody>" +
+            "</table>" +
+            "</div>" +
+            "</div>",
+            title, head.toString(), body.toString()));
+    }
+
+    public void badge(String label, String tone) {
+        String toneKey = tone != null ? tone.toLowerCase() : "";
+        String toneClasses = switch (toneKey) {
+            case "success" -> "bg-green-100 text-green-800 dark:bg-green-900/60 dark:text-green-200";
+            case "warning" -> "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/60 dark:text-yellow-200";
+            case "danger" -> "bg-red-100 text-red-800 dark:bg-red-900/60 dark:text-red-200";
+            case "info" -> "bg-blue-100 text-blue-800 dark:bg-blue-900/60 dark:text-blue-200";
+            default -> "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200";
+        };
+
+        ctx.addHtml(String.format(
+            "<span class='inline-flex items-center px-3 py-1 text-xs font-medium rounded-full %s'>%s</span>",
+            toneClasses, label));
+    }
+}

--- a/sandbox/streamlit-like-jetty/src/main/java/it/jui/framework/apis/LayoutElements.java
+++ b/sandbox/streamlit-like-jetty/src/main/java/it/jui/framework/apis/LayoutElements.java
@@ -1,0 +1,40 @@
+package it.jui.framework.apis;
+
+import it.jui.framework.core.UIContext;
+
+public class LayoutElements extends BaseElements {
+
+    public LayoutElements(UIContext ctx) {
+        super(ctx);
+    }
+
+    public void card(String title, String body) {
+        ctx.addHtml(String.format(
+            "<div class='mb-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm overflow-hidden'>" +
+            "<div class='px-4 py-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40'>" +
+            "<h3 class='text-lg font-semibold text-gray-800 dark:text-gray-100'>%s</h3>" +
+            "</div>" +
+            "<div class='px-4 py-3 text-gray-600 dark:text-gray-300'>%s</div>" +
+            "</div>",
+            title, body));
+    }
+
+    public void metricCard(String label, String value, String trend, boolean trendIsPositive) {
+        String trendClasses = trendIsPositive
+                ? "text-green-600 dark:text-green-400"
+                : "text-red-600 dark:text-red-400";
+        String trendIcon = trendIsPositive
+                ? "<span class='text-xs mr-1'>▲</span>"
+                : "<span class='text-xs mr-1'>▼</span>";
+
+        ctx.addHtml(String.format(
+            "<div class='p-4 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm'>" +
+            "<dl>" +
+            "<dt class='text-sm font-medium text-gray-500 dark:text-gray-400'>%s</dt>" +
+            "<dd class='mt-2 text-3xl font-bold text-gray-900 dark:text-white'>%s</dd>" +
+            "</dl>" +
+            "<p class='mt-2 inline-flex items-center text-sm %s'>%s%s</p>" +
+            "</div>",
+            label, value, trendClasses, trendIcon, trend));
+    }
+}

--- a/sandbox/streamlit-like-jetty/src/main/java/it/jui/framework/apis/NavigationElements.java
+++ b/sandbox/streamlit-like-jetty/src/main/java/it/jui/framework/apis/NavigationElements.java
@@ -1,0 +1,45 @@
+package it.jui.framework.apis;
+
+import java.util.List;
+
+import it.jui.framework.core.UIContext;
+
+public class NavigationElements extends BaseElements {
+
+    public NavigationElements(UIContext ctx) {
+        super(ctx);
+    }
+
+    public String tabs(String label, List<String> options, String defaultOption) {
+        if (options == null || options.isEmpty()) {
+            return "";
+        }
+
+        String id = ctx.getNextWidgetId(label);
+        String initial = defaultOption != null ? defaultOption : options.get(0);
+        String active = ctx.getValue(id, initial);
+
+        StringBuilder sb = new StringBuilder();
+        for (String opt : options) {
+            boolean isActive = opt.equals(active);
+            String classes = isActive
+                    ? "bg-indigo-600 text-white border-indigo-600 shadow-md"
+                    : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-600";
+            sb.append(String.format(
+                "<button onclick=\"sendUpdate('%s', '%s')\" class='px-4 py-2 text-sm font-medium border rounded-md transition %s'>%s</button>",
+                id, opt, classes, opt));
+        }
+
+        ctx.addHtml(String.format(
+            "<div class='mb-6'>" +
+            "<div class='flex items-center justify-between mb-2'>" +
+            "<span class='text-sm font-medium text-gray-700 dark:text-gray-300'>%s</span>" +
+            "<span class='text-xs text-gray-500 dark:text-gray-400'>Selezionato: %s</span>" +
+            "</div>" +
+            "<div class='flex flex-wrap gap-2'>%s</div>" +
+            "</div>",
+            label, active, sb.toString()));
+
+        return active;
+    }
+}

--- a/sandbox/streamlit-like-jetty/src/main/java/it/jui/framework/core/UIContext.java
+++ b/sandbox/streamlit-like-jetty/src/main/java/it/jui/framework/core/UIContext.java
@@ -2,6 +2,9 @@ package it.jui.framework.core;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import it.jui.framework.apis.DataElements;
+import it.jui.framework.apis.LayoutElements;
+import it.jui.framework.apis.NavigationElements;
 import it.jui.framework.apis.StatusElements;
 import it.jui.framework.apis.TextElements;
 import lombok.experimental.Delegate;
@@ -20,13 +23,25 @@ public class UIContext {
     @Delegate
     private final StatusElements statusApis;
 
+    @Delegate
+    private final LayoutElements layoutApis;
+
+    @Delegate
+    private final NavigationElements navigationApis;
+
+    @Delegate
+    private final DataElements dataApis;
+
     public UIContext(String sessionId, SessionManager sessionManager) {
 
         this.sessionId = sessionId;
         this.sessionManager = sessionManager;
-        
+
         textApis = new TextElements(this);
         statusApis = new StatusElements(this);
+        layoutApis = new LayoutElements(this);
+        navigationApis = new NavigationElements(this);
+        dataApis = new DataElements(this);
     }
 
     public String getHtml() { return htmlOutput.toString(); }


### PR DESCRIPTION
## Summary
- add Tailwind-based navigation, layout, and data helper classes for the streamlit-like sandbox
- expose the new helpers via UIContext and demonstrate them inside the sample TestApp
- document the additional APIs in the sandbox README

## Testing
- mvn -q test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925bae867648332b97d8de286a5a899)